### PR TITLE
Redirect old discourse instances to discourse.mozilla.org

### DIFF
--- a/config.py
+++ b/config.py
@@ -118,4 +118,19 @@ class Config(object):
             ReturnCodes.TEMPORARY,
             (False, False)
         ),
+        'forum.learning.mozilla.org': (
+            'https://discourse.mozilla.org/',
+            ReturnCodes.TEMPORARY,
+            (False, False)
+        ),
+        'discourse.mozilla-advocacy.org': (
+            'https://discourse.mozilla.org/',
+            ReturnCodes.TEMPORARY,
+            (False, False)
+        ),
+        'forum.mozillascience.org': (
+            'https://discourse.mozilla.org/',
+            ReturnCodes.TEMPORARY,
+            (False, False)
+        ),
     }


### PR DESCRIPTION
Add forum learning, discourse advocacy, and forum mozillascience to all redirect to discourse.mozilla.org.