### PR TITLE
Add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .env
 __pycache__
 .idea/
+
+# Nix Shell
+.envrc
+shell.nix

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ install:
   - pipenv install -d
 script:
   - pipenv run flake8 ./ --config=./tox.ini
+  - pipenv run pytest

--- a/Pipfile
+++ b/Pipfile
@@ -13,4 +13,4 @@ python-dotenv = "*"
 pytest = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.7"

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ python-dotenv = "*"
 
 [dev-packages]
 "flake8" = "*"
+pytest = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "963bcb98b75a3ab743ebb7830984be01740c80e44d0125b558945d5ab5106ba8"
+            "sha256": "94eccae463c1ccbc56e4566f2c1ba086e75c8187930c45fa72a8f93811bfea77"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.7"
         },
         "sources": [
             {
@@ -155,10 +155,10 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
-                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
+                "sha256:a7ac867b97fdc07ee80a8058fe4435ccd274ecc3b0ed61d852d7d53055528cf9",
+                "sha256:c491ca87294da7cc01902edbe30a5bc6c4c28172b5138ab4e4aa1b9d7bfaeafe"
             ],
-            "version": "==19.0"
+            "version": "==19.1"
         },
         "pluggy": {
             "hashes": [
@@ -190,10 +190,10 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:43c5486cefefa536c9aab528881c992328f020eefe4f6d06332449c365218580",
-                "sha256:d6c5ffe9d0305b9b977f7a642d36b9370954d1da7ada4c62393382cbadad4265"
+                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
+                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
             ],
-            "version": "==2.4.1.1"
+            "version": "==2.4.2"
         },
         "pytest": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a1b811970591051d376a515d6e33136203cf8810cb977e8c9ebaf87928e11440"
+            "sha256": "963bcb98b75a3ab743ebb7830984be01740c80e44d0125b558945d5ab5106ba8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,18 +18,18 @@
     "default": {
         "click": {
             "hashes": [
-                "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
-                "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
-            "version": "==6.7"
+            "version": "==7.0"
         },
         "flask": {
             "hashes": [
-                "sha256:2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48",
-                "sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05"
+                "sha256:13f9f196f330c7c2c5d7a5cf91af894110ca0215ac051b5844701f2bfd934d52",
+                "sha256:45eb5a6fd193d6cf7e0cf5d8a5b31f83d5faae0293695626f539a823e93b13f6"
             ],
             "index": "pypi",
-            "version": "==1.0.2"
+            "version": "==1.1.1"
         },
         "gunicorn": {
             "hashes": [
@@ -41,47 +41,103 @@
         },
         "itsdangerous": {
             "hashes": [
-                "sha256:cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519"
+                "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
+                "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"
             ],
-            "version": "==0.24"
+            "version": "==1.1.0"
         },
         "jinja2": {
             "hashes": [
-                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
-                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
             ],
-            "version": "==2.10"
+            "version": "==2.10.1"
         },
         "markupsafe": {
             "hashes": [
-                "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
             ],
-            "version": "==1.0"
+            "version": "==1.1.1"
         },
         "python-dotenv": {
             "hashes": [
-                "sha256:122290a38ece9fe4f162dc7c95cae3357b983505830a154d3c98ef7f6c6cea77",
-                "sha256:4a205787bc829233de2a823aa328e44fd9996fedb954989a21f1fc67c13d7a77"
+                "sha256:debd928b49dbc2bf68040566f55cdb3252458036464806f4094487244e2a4093",
+                "sha256:f157d71d5fec9d4bd5f51c82746b6344dffa680ee85217c123f4a0c8117c4544"
             ],
             "index": "pypi",
-            "version": "==0.9.1"
+            "version": "==0.10.3"
         },
         "werkzeug": {
             "hashes": [
-                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
-                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
+                "sha256:87ae4e5b5366da2347eb3116c0e6c681a0e939a33b2805e2c0cbd282664932c4",
+                "sha256:a13b74dd3c45f758d4ebdb224be8f1ab8ef58b3c0ffc1783a8c7d9f4f50227e6"
             ],
-            "version": "==0.14.1"
+            "version": "==0.15.5"
         }
     },
     "develop": {
+        "atomicwrites": {
+            "hashes": [
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+            ],
+            "version": "==1.3.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+            ],
+            "version": "==19.1.0"
+        },
+        "entrypoints": {
+            "hashes": [
+                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
+                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
+            ],
+            "version": "==0.3"
+        },
         "flake8": {
             "hashes": [
-                "sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0",
-                "sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37"
+                "sha256:19241c1cbc971b9962473e4438a2ca19749a7dd002dd1a946eaba171b4114548",
+                "sha256:8e9dfa3cecb2400b3738a42c54c3043e821682b9c840b0448c0503f781130696"
             ],
             "index": "pypi",
-            "version": "==3.5.0"
+            "version": "==3.7.8"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:23d3d873e008a513952355379d93cbcab874c58f4f034ff657c7a87422fa64e8",
+                "sha256:80d2de76188eabfbfcf27e6a37342c2827801e59c4cc14b0371c56fed43820e3"
+            ],
+            "version": "==0.19"
         },
         "mccabe": {
             "hashes": [
@@ -90,19 +146,83 @@
             ],
             "version": "==0.6.1"
         },
+        "more-itertools": {
+            "hashes": [
+                "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832",
+                "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"
+            ],
+            "version": "==7.2.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
+                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
+            ],
+            "version": "==19.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
+                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
+            ],
+            "version": "==0.12.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
+            ],
+            "version": "==1.8.0"
+        },
         "pycodestyle": {
             "hashes": [
-                "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766",
-                "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9"
+                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
+                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
             ],
-            "version": "==2.3.1"
+            "version": "==2.5.0"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:08bd6a50edf8cffa9fa09a463063c425ecaaf10d1eb0335a7e8b1401aef89e6f",
-                "sha256:8d616a382f243dbf19b54743f280b80198be0bca3a5396f1d2e1fca6223e8805"
+                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
+                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
             ],
-            "version": "==1.6.0"
+            "version": "==2.1.1"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:43c5486cefefa536c9aab528881c992328f020eefe4f6d06332449c365218580",
+                "sha256:d6c5ffe9d0305b9b977f7a642d36b9370954d1da7ada4c62393382cbadad4265"
+            ],
+            "version": "==2.4.1.1"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:6ef6d06de77ce2961156013e9dff62f1b2688aa04d0dc244299fe7d67e09370d",
+                "sha256:a736fed91c12681a7b34617c8fcefe39ea04599ca72c608751c31d89579a3f77"
+            ],
+            "index": "pypi",
+            "version": "==5.0.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+            ],
+            "version": "==0.1.7"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a",
+                "sha256:8a5712cfd3bb4248015eb3b0b3c54a5f6ee3f2425963ef2a0125b8bc40aafaec"
+            ],
+            "version": "==0.5.2"
         }
     }
 }

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn app:app
+web: gunicorn app:create_app()

--- a/app.py
+++ b/app.py
@@ -11,83 +11,90 @@ from flask import (
     abort,
 )
 
-app = Flask(__name__, static_folder=None)
 
-app.config.from_object('config.Config')
+def create_app(test_config=None):
+    app = Flask(__name__, static_folder=None)
 
-redirect_rules = app.config['REDIRECT_RULES']
-force_ssl = app.config['FORCE_SSL']
-debug = app.config['DEBUG']
-
-
-@app.before_request
-def enforce_ssl():
-    if not force_ssl:
-        return None
-
-    proto = request.headers.get('X-Forwarded-Proto', None)
-
-    if proto == 'https':
-        return None
-
-    url = request.url.replace('http://', 'https://', 1)
-    return redirect(url, code=301)
-
-
-@app.route('/', defaults={'path': ''})
-@app.route('/<path:path>')
-def redirector(path):
-    x_forwarded_host = request.headers.get('X-Forwarded-Host', None)
-
-    if x_forwarded_host:
-        host = x_forwarded_host
+    if test_config is None:
+        app.config.from_object('config.Config')
     else:
-        host = request.headers.get('Host', None)
+        app.config.update(test_config)
 
-    if debug:
-        print('received request from {}'.format(host))
+    redirect_rules = app.config['REDIRECT_RULES']
+    force_ssl = app.config['FORCE_SSL']
+    debug = app.config['DEBUG']
 
-    if host in redirect_rules:
-        redirect_target, redirect_code, preserves = redirect_rules[host]
-        preserve_path, preserve_query = preserves
 
-        redirect_path = ''
-        redirect_query = ''
+    @app.before_request
+    def enforce_ssl():
+        if not force_ssl:
+            return None
 
-        target_url = urlparse(redirect_target)
+        proto = request.headers.get('X-Forwarded-Proto', None)
 
-        if preserve_path:
-            redirect_path = path
+        if proto == 'https':
+            return None
+
+        url = request.url.replace('http://', 'https://', 1)
+        return redirect(url, code=301)
+
+
+    @app.route('/', defaults={'path': ''})
+    @app.route('/<path:path>')
+    def redirector(path):
+        x_forwarded_host = request.headers.get('X-Forwarded-Host', None)
+
+        if x_forwarded_host:
+            host = x_forwarded_host
         else:
-            redirect_path = target_url.path
-
-        if preserve_query:
-            redirect_query = urlencode(request.args, doseq=True)
-
-        redirect_parse = ParseResult(
-            scheme=target_url.scheme,
-            netloc=target_url.netloc,
-            path=redirect_path,
-            query=redirect_query,
-            params='',
-            fragment=''
-        )
-
-        final_redirect = urlunparse(redirect_parse)
+            host = request.headers.get('Host', None)
 
         if debug:
-            print('redirecting to {} with a {}'.format(final_redirect, redirect_code.value))
+            print('received request from {}'.format(host))
 
-        return redirect(final_redirect, code=redirect_code.value)
+        if host in redirect_rules:
+            redirect_target, redirect_code, preserves = redirect_rules[host]
+            preserve_path, preserve_query = preserves
 
-    return abort(400)
+            redirect_path = ''
+            redirect_query = ''
+
+            target_url = urlparse(redirect_target)
+
+            if preserve_path:
+                redirect_path = path
+            else:
+                redirect_path = target_url.path
+
+            if preserve_query:
+                redirect_query = urlencode(request.args, doseq=True)
+
+            redirect_parse = ParseResult(
+                scheme=target_url.scheme,
+                netloc=target_url.netloc,
+                path=redirect_path,
+                query=redirect_query,
+                params='',
+                fragment=''
+            )
+
+            final_redirect = urlunparse(redirect_parse)
+
+            if debug:
+                print('redirecting to {} with a {}'.format(final_redirect, redirect_code.value))
+
+            return redirect(final_redirect, code=redirect_code.value)
+
+        return abort(400)
 
 
-@app.after_request
-def response_headers(response):
-    response.headers['Server'] = 'MoFo Redirector'
-    return response
+    @app.after_request
+    def response_headers(response):
+        response.headers['Server'] = 'MoFo Redirector'
+        return response
+
+    return app
 
 
 if __name__ == '__main__':
-    app.run()
+    create_app().run()

--- a/app.py
+++ b/app.py
@@ -24,7 +24,6 @@ def create_app(test_config=None):
     force_ssl = app.config['FORCE_SSL']
     debug = app.config['DEBUG']
 
-
     @app.before_request
     def enforce_ssl():
         if not force_ssl:
@@ -37,7 +36,6 @@ def create_app(test_config=None):
 
         url = request.url.replace('http://', 'https://', 1)
         return redirect(url, code=301)
-
 
     @app.route('/', defaults={'path': ''})
     @app.route('/<path:path>')
@@ -86,7 +84,6 @@ def create_app(test_config=None):
             return redirect(final_redirect, code=redirect_code.value)
 
         return abort(400)
-
 
     @app.after_request
     def response_headers(response):

--- a/config.py
+++ b/config.py
@@ -39,7 +39,7 @@ class Config(object):
 
     # Redirect Rules
     # The key is the host header to match
-    # At [0]: the redirect target, without trailing slash
+    # At [0]: the redirect target, without trailing slash, prefixed by https
     # At [1]: the HTTP status code to return - use the ReturnCodes enum
     # At [2]: a Tuple, indicating if the path and query are to be preserved ( {path}, {query} )
     REDIRECT_RULES = {

--- a/run.py
+++ b/run.py
@@ -1,4 +1,0 @@
-from app import app
-
-if __name__ == '__main__':
-    app.run()

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.8
+python-3.7.3

--- a/test_app.py
+++ b/test_app.py
@@ -1,0 +1,86 @@
+from app import create_app
+from config import ReturnCodes
+
+
+def assert_redirect(response, expected_status_code, expected_location):
+    assert response.status_code == expected_status_code
+    assert response.headers["Location"] == expected_location
+
+
+def client(rules):
+    config = {
+        "REDIRECT_RULES": rules,
+        "FORCE_SSL": False,
+        "DEBUG": False
+    }
+    return create_app(config).test_client()
+
+
+def test_permanent_redirect():
+    test_client = client(
+        {'example.com': (
+            "https://another-example.com",
+            ReturnCodes.PERMANENT,
+            (False, False)
+        )}
+    )
+
+    r = test_client.get("/", headers=[("Host", "example.com")])
+
+    assert_redirect(r, 301, "https://another-example.com")
+
+
+def test_temporary_redirect():
+    test_client = client(
+        {'example.com': (
+            "https://another-example.com",
+            ReturnCodes.TEMPORARY,
+            (False, False)
+        )}
+    )
+
+    r = test_client.get("/", headers=[("Host", "example.com")])
+
+    assert_redirect(r, 307, "https://another-example.com")
+
+
+def test_keep_query():
+    test_client = client(
+        {'example.com': (
+            "https://another-example.com",
+            ReturnCodes.TEMPORARY,
+            (False, True)
+        )}
+    )
+
+    r = test_client.get("/", headers=[("Host", "example.com")], query_string="such_query=very_value")
+
+    assert_redirect(r, 307, "https://another-example.com?such_query=very_value")
+
+
+def test_keep_path():
+    test_client = client(
+        {'example.com': (
+            "https://another-example.com",
+            ReturnCodes.TEMPORARY,
+            (True, False)
+        )}
+    )
+
+    r = test_client.get("/robots.txt", headers=[("Host", "example.com")])
+
+    assert_redirect(r, 307, "https://another-example.com/robots.txt")
+
+
+def test_keep_path_and_query():
+    test_client = client(
+        {'example.com': (
+            "https://another-example.com",
+            ReturnCodes.TEMPORARY,
+            (True, True)
+        )}
+    )
+
+    r = test_client.get("/robots.txt", headers=[("Host", "example.com")], query_string="such_query=very_value")
+
+    assert_redirect(r, 307, "https://another-example.com/robots.txt?such_query=very_value")


### PR DESCRIPTION
close #19 

- Test that redirections work,
- update dependencies,
- move to python 3.7
- remove the `run.py` file that was not used.

I had to do some changes in `app.py` to be able to change the config passed to the flask app. Now, we can call the flask app with prod config by default, or the test one [when running the tests](https://github.com/mozilla/mofo-redirector/blob/tests/test_app.py#L16).