### PR TITLE
Fix procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn app:create_app()
+web: gunicorn "app:create_app()"


### PR DESCRIPTION
follow PR to fix #20 

from logs:
```
 14:22:06.257 mofo-redirector logplex <190>1 2019-07-31T12:22:03.741720+00:00 host app web.1 - bash: -c: line 0: syntax error near unexpected token `('
14:22:06.257 mofo-redirector logplex <190>1 2019-07-31T12:22:03.741742+00:00 host app web.1 - bash: -c: line 0: `gunicorn app:create_app()'
14:22:06.258 mofo-redirector logplex <158>1 2019-07-31T12:22:04.576069+00:00 host heroku router - at=error code=H10 desc="App crashed" method=GET path="/?id=2" host=forum.mozillascience.org request_id=05284ad9-92c8-4688-8c37-963fce1443c3 fwd="101.249.50.135" dyno= connect= service= status=503 bytes= protocol=http
```