### PR TITLE
Add redirect for backpack

### DIFF
--- a/config.py
+++ b/config.py
@@ -178,4 +178,14 @@ class Config(object):
             ReturnCodes.PERMANENT,
             (False, False)
         ),
+        'backpack.openbadges.org': (
+            'https://backpack.openbadges.org.badgr.io',
+            ReturnCodes.TEMPORARY,
+            (False, False)
+        ),
+        'beta.openbadges.org': (
+            'https://foundation.mozilla.org/en/artifacts/mozilla-backpack',
+            ReturnCodes.TEMPORARY,
+            (False, False)
+        ),
     }


### PR DESCRIPTION
- redirect `backpack.openbadges.org` to their site,
- redirect `beta.openbadges.org` to the backpack artifact page on the foundation site. We might revisit this when I have the time to deal with them about the certificate.

Related PRs: MozillaFoundation/mofo-devops-private#243, MozillaFoundation/mofo-devops-private#252

When it's merged: update route53 for both (I'll do it).