### PR TITLE
Add configuration for redirecting discourse.mozillafestival.org

### DIFF
--- a/config.py
+++ b/config.py
@@ -188,4 +188,9 @@ class Config(object):
             ReturnCodes.TEMPORARY,
             (False, False)
         ),
+        'dicourse.mozillafestival.org': (
+            'https://discourse-mozfest-redirect.netlify.com',
+            ReturnCodes.TEMPORARY,
+            (True, True)
+        ),
     }


### PR DESCRIPTION
 to discourse-mozfest-redirect.netlify.com

MozillaFoundation/mofo-devops#706