### PR TITLE
add a redirect for firefox10.org and www.firefox10.org

### DIFF
--- a/config.py
+++ b/config.py
@@ -188,4 +188,14 @@ class Config(object):
             ReturnCodes.TEMPORARY,
             (False, False)
         ),
+        'firefox10.org': (
+            'https://foundation.mozilla.org',
+            ReturnCodes.TEMPORARY,
+            (False, False)
+        ),
+        'www.firefox10.org': (
+            'https://foundation.mozilla.org',
+            ReturnCodes.TEMPORARY,
+            (False, False)
+        ),
     }


### PR DESCRIPTION
As per conversation in slack with @alanmoo