### PR TITLE
Redirect give.mozilla.org, preserve path and query

### DIFF
--- a/config.py
+++ b/config.py
@@ -227,7 +227,12 @@ class Config(object):
             'https://foundation.mozilla.org/en/artifacts/thimble/',
             ReturnCodes.TEMPORARY,
             (False, False)
-        )
+        ),
+        'give.mozilla.org': (
+            'https://donate.mozilla.org',
+            ReturnCodes.TEMPORARY,
+            (True, True)
+        ),
         #
         # Disabled for now due to large volumes of non-user traffic
         # 'beta.openbadges.org': (


### PR DESCRIPTION
We'll need this on the redirector app for the launch tomorrow.