### PR TITLE
add redirection for learning.mozilla.org

### DIFF
--- a/config.py
+++ b/config.py
@@ -233,6 +233,11 @@ class Config(object):
             ReturnCodes.TEMPORARY,
             (True, True)
         ),
+        'learning.mozilla.org': (
+            'https://foundation.mozilla.org/en/opportunity/web-literacy/',
+            ReturnCodes.PERMANENT,
+            (True, True)
+        ),
         #
         # Disabled for now due to large volumes of non-user traffic
         # 'beta.openbadges.org': (

--- a/config.py
+++ b/config.py
@@ -238,6 +238,11 @@ class Config(object):
             ReturnCodes.PERMANENT,
             (True, True)
         ),
+        'teach.mozilla.org': (
+            'https://foundation.mozilla.org/en/opportunity/web-literacy/',
+            ReturnCodes.PERMANENT,
+            (True, True)
+        ),
         #
         # Disabled for now due to large volumes of non-user traffic
         # 'beta.openbadges.org': (

--- a/config.py
+++ b/config.py
@@ -236,12 +236,13 @@ class Config(object):
         'learning.mozilla.org': (
             'https://foundation.mozilla.org/en/opportunity/web-literacy/',
             ReturnCodes.TEMPORARY,
-            (True, True)
+            (False, True)
         ),
         'teach.mozilla.org': (
             'https://foundation.mozilla.org/en/opportunity/web-literacy/',
             ReturnCodes.TEMPORARY,
-            (True, True)
+            (False, True)
+
         ),
         'www.webmaker.org': (
             'https://foundation.mozilla.org/en/artifacts/webmaker/',

--- a/config.py
+++ b/config.py
@@ -235,12 +235,12 @@ class Config(object):
         ),
         'learning.mozilla.org': (
             'https://foundation.mozilla.org/en/opportunity/web-literacy/',
-            ReturnCodes.PERMANENT,
+            ReturnCodes.TEMPORARY,
             (True, True)
         ),
         'teach.mozilla.org': (
             'https://foundation.mozilla.org/en/opportunity/web-literacy/',
-            ReturnCodes.PERMANENT,
+            ReturnCodes.TEMPORARY,
             (True, True)
         ),
         #


### PR DESCRIPTION
We're sunsetting learning.mozilla.org and we want to redirect all traffic to an artifact page.

Todos once merged:
- [x] `heroku domains:add learning.mozilla.org -a mofo-redirector`
- [x] `heroku certs -a mofo-redirector`
