### PR TITLE
remove unused rules - mozilla sciences

### DIFF
--- a/config.py
+++ b/config.py
@@ -269,16 +269,6 @@ class Config(object):
             ReturnCodes.PERMANENT,
             (False, False)
         ),
-        'mozillascience.org': (
-            'https://wiki.mozilla.org/ScienceLab',
-            ReturnCodes.PERMANENT,
-            (False, False)
-        ),
-        'www.mozillascience.org': (
-            'https://wiki.mozilla.org/ScienceLab',
-            ReturnCodes.PERMANENT,
-            (False, False)
-        ),
         #
         # Disabled for now due to large volumes of non-user traffic
         # 'beta.openbadges.org': (


### PR DESCRIPTION
I misread the CF and S3 redirection and we don't actually need any redirection for `mozillascience.org` and `www.mozillascience.org`: they both point to `science.mozilla.org`.