### PR TITLE
We don't need a redirect for codemoji

### DIFF
--- a/config.py
+++ b/config.py
@@ -259,11 +259,6 @@ class Config(object):
             ReturnCodes.PERMANENT,
             (False, True)
         ),
-        'codemoji.org': (
-            'https://foundation.mozilla.org/en/campaigns/codemoji/',
-            ReturnCodes.PERMANENT,
-            (False, False)
-        ),
         'science.mozilla.org': (
             'https://wiki.mozilla.org/ScienceLab',
             ReturnCodes.PERMANENT,


### PR DESCRIPTION
Remove the codemoji entry from the config file.
Close mozillaFoundation/mofo-devops-private#310