### PR TITLE
added redirect for donate.mozilla.org

### DIFF
--- a/config.py
+++ b/config.py
@@ -53,6 +53,11 @@ class Config(object):
             ReturnCodes.PERMANENT,
             (False, False),
         ),
+        'donate.mozilla.org': (
+            'https://foundation.mozilla.org/donate',
+            ReturnCodes.PERMANENT,
+            (True, True),
+        ),
         'www.hivelearningnetwork.org': (
             'https://foundation.mozilla.org/en/artifacts/hive-learning-networks',
             ReturnCodes.PERMANENT,


### PR DESCRIPTION
This PR adds a redirect from the legacy donate stack URL (https://donate.mozilla.org) and redirects it to the new donate page on the foundation site (https://foundation.mozilla.org/donate).


