### PR TITLE
Redirection config added for movementbuilding and compass

### DIFF
--- a/config.py
+++ b/config.py
@@ -49,13 +49,13 @@ class Config(object):
             (True, True),
         ),
         'compass.mozillafoundation.org': (
-            'https://foundation.mozilla.org/en/404/',
-            ReturnCodes.TEMPORARY,
+            'https://foundation.mozilla.org/404/',
+            ReturnCodes.PERMANENT,
             (False, False),
         ),
         'movementbuilding.mozillafoundation.org': (
-            'https://foundation.mozilla.org/en/404/',
-            ReturnCodes.TEMPORARY,
+            'https://foundation.mozilla.org/404/',
+            ReturnCodes.PERMANENT,
             (False, False),
         ),
         'chat.mozillafoundation.org': (

--- a/config.py
+++ b/config.py
@@ -48,6 +48,16 @@ class Config(object):
             ReturnCodes.TEMPORARY,
             (True, True),
         ),
+        'compass.mozillafoundation.org': (
+            'https://foundation.mozilla.org/en/404/',
+            ReturnCodes.TEMPORARY,
+            (False, False),
+        ),
+        'movementbuilding.mozillafoundation.org': (
+            'https://foundation.mozilla.org/en/404/',
+            ReturnCodes.TEMPORARY,
+            (False, False),
+        ),
         'chat.mozillafoundation.org': (
             'https://mozfest.slack.com',
             ReturnCodes.PERMANENT,


### PR DESCRIPTION
This PR creates a redirect for movementbuilding and compass. Following Jira tickets:

1. [movementbuilding](https://mozilla-hub.atlassian.net/browse/TP1-1535)
2. [compass](https://mozilla-hub.atlassian.net/browse/TP1-1536)