### PR TITLE
Temporarily suspend the robots.txt Disallow for SEO crawl

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,7 +90,7 @@ def create_app(test_config=None):
 
     @app.route("/robots.txt")
     def send_robots_txt():
-        response = make_response("User-agent: *\nDisallow: /")
+        response = make_response("User-agent: *\n")
         response.headers["Content-Type"] = "text/plain; charset=utf-8"
         return response
 

--- a/test_app.py
+++ b/test_app.py
@@ -10,7 +10,7 @@ def assert_redirect(response, expected_status_code, expected_location):
 
 def assert_robots(response):
     assert response.status_code == 200
-    assert response.get_data(as_text=True) == "User-agent: *\nDisallow: /"
+    assert response.get_data(as_text=True) == "User-agent: *\n"
 
 
 def client(rules):


### PR DESCRIPTION
This PR temporarily removes the disallow from robots.txt for an SEO crawl of the redirects for the domain swap. Will be reverted after testing.