### PR TITLE
Redirect non-WWW to www.mozillafoundation.org

### DIFF
--- a/config.py
+++ b/config.py
@@ -303,5 +303,10 @@ class Config(object):
             'https://www.mozillafoundation.org',
             ReturnCodes.PERMANENT,
             (True, True),
+        ),
+        'mozillafoundation.org': (
+            'https://www.mozillafoundation.org',
+            ReturnCodes.PERMANENT,
+            (True, True),
         )
     }


### PR DESCRIPTION
This PR adds a rule to redirect mozillafoundation.org to www.mozillafoundation.org