### PR TITLE
Redirect movement building URL

### DIFF
--- a/config.py
+++ b/config.py
@@ -54,7 +54,7 @@ class Config(object):
             (False, False),
         ),
         'movementbuilding.mozillafoundation.org': (
-            'https://www.mozillafoundation.org/404/',
+            'https://www.mozillafoundation.org/en/research/library/movement-building-landscape-analysis-acting-on-shared-purpose/',
             ReturnCodes.PERMANENT,
             (False, False),
         ),

--- a/config.py
+++ b/config.py
@@ -54,7 +54,7 @@ class Config(object):
             (False, False),
         ),
         'movementbuilding.mozillafoundation.org': (
-            'https://www.mozillafoundation.org/en/research/library/' \
+            'https://www.mozillafoundation.org/en/research/library/'
             'movement-building-landscape-analysis-acting-on-shared-purpose',
             ReturnCodes.PERMANENT,
             (False, False),

--- a/config.py
+++ b/config.py
@@ -54,7 +54,8 @@ class Config(object):
             (False, False),
         ),
         'movementbuilding.mozillafoundation.org': (
-            'https://www.mozillafoundation.org/en/research/library/movement-building-landscape-analysis-acting-on-shared-purpose/',
+            'https://www.mozillafoundation.org/en/research/library/' \
+            'movement-building-landscape-analysis-acting-on-shared-purpose',
             ReturnCodes.PERMANENT,
             (False, False),
         ),


### PR DESCRIPTION
This PR will redirect movement building properly via the mofo-redirector instead of to 404